### PR TITLE
Fix UUID scalar type in GraphQL schema

### DIFF
--- a/src/types/map-scalars.ts
+++ b/src/types/map-scalars.ts
@@ -19,5 +19,5 @@ export const scalarMap: Record<string, any> = {
     json: JSONObjectResolver,
     id: GraphQLID,
     text: GraphQLString, // alias for long-form strings
-    uuid: GraphQLString, // alias for UUIDs
+    uuid: GraphQLID, // alias for UUIDs
 };


### PR DESCRIPTION
Change the UUID scalar type from GraphQLString to GraphQLID for correct representation.