### PR TITLE
Simplify id argument structure in get resolver

### DIFF
--- a/src/resolvers/generate-query-resolvers.ts
+++ b/src/resolvers/generate-query-resolvers.ts
@@ -36,7 +36,7 @@ export const generateQueryResolvers = ({
         [`get${name}`]: {
             type,
             args: {
-                id: { type: idType }
+                id: idType
             },
             resolve: async (_: any, args: any, context: AuthContext) => {
                 return await Sentry.startSpan({ name: `get${name}`, op: 'graphql.query' }, async () => {


### PR DESCRIPTION
Refactor the id argument in the get resolver to streamline its structure.