### PR TITLE
Replace Object.assign with explicit field assignment for clarity and error handling

### DIFF
--- a/src/schema/unified-schema.ts
+++ b/src/schema/unified-schema.ts
@@ -12,9 +12,9 @@ interface ModelSchema {
 export function buildUnifiedGraphQLSchemaFromFolder(modelsDir: string): GraphQLSchema {
     const modelFiles = fs.readdirSync(modelsDir).filter(f => f.endsWith('.ts'));
 
-    const queryFields: any = {};
-    const mutationFields: any = {};
-    const subscriptionFields: any = {};
+    const queryFields: Record<string, any> = {};
+    const mutationFields: Record<string, any> = {};
+    const subscriptionFields: Record<string, any> = {};
 
     for (const file of modelFiles) {
         const modelPath = path.join(modelsDir, file);
@@ -25,17 +25,35 @@ export function buildUnifiedGraphQLSchemaFromFolder(modelsDir: string): GraphQLS
 
         const queryType = modelSchema.getQueryType();
         if (queryType) {
-            Object.assign(queryFields, queryType.getFields());
+            const fields = queryType.getFields();
+            for (const [key, value] of Object.entries(fields)) {
+                if (value.args && Array.isArray(value.args)) {
+                    throw new Error(`Query.${key} args must be an object, but received an array.`);
+                }
+                queryFields[key] = value;
+            }
         }
 
         const mutationType = modelSchema.getMutationType();
         if (mutationType) {
-            Object.assign(mutationFields, mutationType.getFields());
+            const fields = mutationType.getFields();
+            for (const [key, value] of Object.entries(fields)) {
+                if (value.args && Array.isArray(value.args)) {
+                    throw new Error(`Mutation.${key} args must be an object, but received an array.`);
+                }
+                mutationFields[key] = value;
+            }
         }
 
         const subscriptionType = modelSchema.getSubscriptionType();
         if (subscriptionType) {
-            Object.assign(subscriptionFields, subscriptionType.getFields());
+            const fields = subscriptionType.getFields();
+            for (const [key, value] of Object.entries(fields)) {
+                if (value.args && Array.isArray(value.args)) {
+                    throw new Error(`Subscription.${key} args must be an object, but received an array.`);
+                }
+                subscriptionFields[key] = value;
+            }
         }
     }
 


### PR DESCRIPTION
Enhance clarity and error handling by replacing `Object.assign` with explicit field assignments in the GraphQL schema building process. This change ensures better validation of argument types for queries, mutations, and subscriptions.