### PR TITLE
Simplify GraphQL schema generation and integration

### DIFF
--- a/src/generators/get-graphql-schema-for.ts
+++ b/src/generators/get-graphql-schema-for.ts
@@ -9,36 +9,22 @@ import { generateMutationResolvers } from '../resolvers/generate-mutation-resolv
 import { generateSubscriptionResolvers } from '../resolvers/generate-subscription-resolvers';
 import { GraphQLModel } from '../types/graphql-model';
 
-export const getGraphQLSchemaForModel = (model: GraphQLModel, name: string): GraphQLSchema => {
+export const getGraphQLSchemaForModel = (model: GraphQLModel, name: string) => {
     const objectType = generateObjectType(name, model);
     const inputType = generateInputType(name, model);
     const filterType = generateFilterType(name, model);
     const sortType = generateSortType(name, model);
     const pagingInput = generatePagingInput(name);
 
-    const query = new GraphQLObjectType({
-        name: 'Query',
-        fields: () => generateQueryResolvers({ name, model, type: objectType, filter: filterType, sort: sortType, paging: pagingInput })
-    });
+    const queryFields = generateQueryResolvers({ name, model, type: objectType, filter: filterType, sort: sortType, paging: pagingInput });
+    const mutationFields = generateMutationResolvers({ name, model, type: objectType, input: inputType });
+    const subscriptionFields = generateSubscriptionResolvers({ name, type: objectType });
 
-    const mutation = new GraphQLObjectType({
-        name: 'Mutation',
-        fields: () => generateMutationResolvers({ name, model, type: objectType, input: inputType })
-    });
-
-    const subscription = new GraphQLObjectType({
-        name: 'Subscription',
-        fields: () => generateSubscriptionResolvers({ name, type: objectType })
-    });
-    console.log('🧪 Query fields:', query.getFields());
-    console.log('🧪 Mutation fields:', mutation.getFields());
-    console.log('🧪 Subscription fields:', subscription.getFields());
-    
-    return new GraphQLSchema({
-        query,
-        mutation,
-        subscription
-    });
+    return {
+        queryFields,
+        mutationFields,
+        subscriptionFields
+    };
 }
 export const getGraphQLTypesForModel = (model: GraphQLModel, name: string) => {
     return {

--- a/src/schema/unified-schema.ts
+++ b/src/schema/unified-schema.ts
@@ -21,40 +21,11 @@ export function buildUnifiedGraphQLSchemaFromFolder(modelsDir: string): GraphQLS
         const modelName = path.basename(file, '.ts');
         const { default: model } = require(modelPath) as { default: GraphQLModel };
 
-        const modelSchema = getGraphQLSchemaForModel(model, model.name || modelName);
+        const { queryFields: q, mutationFields: m, subscriptionFields: s } = getGraphQLSchemaForModel(model, model.name || modelName);
 
-        const queryType = modelSchema.getQueryType();
-        if (queryType) {
-            const fields = queryType.getFields();
-            for (const [key, value] of Object.entries(fields)) {
-                if (value.args && Array.isArray(value.args)) {
-                    throw new Error(`Query.${key} args must be an object, but received an array.`);
-                }
-                queryFields[key] = value;
-            }
-        }
-
-        const mutationType = modelSchema.getMutationType();
-        if (mutationType) {
-            const fields = mutationType.getFields();
-            for (const [key, value] of Object.entries(fields)) {
-                if (value.args && Array.isArray(value.args)) {
-                    throw new Error(`Mutation.${key} args must be an object, but received an array.`);
-                }
-                mutationFields[key] = value;
-            }
-        }
-
-        const subscriptionType = modelSchema.getSubscriptionType();
-        if (subscriptionType) {
-            const fields = subscriptionType.getFields();
-            for (const [key, value] of Object.entries(fields)) {
-                if (value.args && Array.isArray(value.args)) {
-                    throw new Error(`Subscription.${key} args must be an object, but received an array.`);
-                }
-                subscriptionFields[key] = value;
-            }
-        }
+        Object.assign(queryFields, q);
+        Object.assign(mutationFields, m);
+        Object.assign(subscriptionFields, s);
     }
 
     const query = new GraphQLObjectType({


### PR DESCRIPTION
Refactor the `getGraphQLSchemaForModel` function to return a simplified structure and integrate its output directly into `buildUnifiedGraphQLSchemaFromFolder`, enhancing clarity and maintainability.