### PR TITLE
Update GraphQL schema generation and enhance logging

### DIFF
--- a/src/generators/get-graphql-schema-for.ts
+++ b/src/generators/get-graphql-schema-for.ts
@@ -9,7 +9,39 @@ import { generateMutationResolvers } from '../resolvers/generate-mutation-resolv
 import { generateSubscriptionResolvers } from '../resolvers/generate-subscription-resolvers';
 import { GraphQLModel } from '../types/graphql-model';
 
-export const getGraphQLSchemaForModel = (model: GraphQLModel, name: string) => {
+export const getGraphQLSchemaForModel = (model: GraphQLModel, name: string): GraphQLSchema => {
+    const objectType = generateObjectType(name, model);
+    const inputType = generateInputType(name, model);
+    const filterType = generateFilterType(name, model);
+    const sortType = generateSortType(name, model);
+    const pagingInput = generatePagingInput(name);
+
+    const query = new GraphQLObjectType({
+        name: 'Query',
+        fields: () => generateQueryResolvers({ name, model, type: objectType, filter: filterType, sort: sortType, paging: pagingInput })
+    });
+
+    const mutation = new GraphQLObjectType({
+        name: 'Mutation',
+        fields: () => generateMutationResolvers({ name, model, type: objectType, input: inputType })
+    });
+
+    const subscription = new GraphQLObjectType({
+        name: 'Subscription',
+        fields: () => generateSubscriptionResolvers({ name, type: objectType })
+    });
+    console.log('🧪 Query fields:', query.getFields());
+    console.log('🧪 Mutation fields:', mutation.getFields());
+    console.log('🧪 Subscription fields:', subscription.getFields());
+    
+    return new GraphQLSchema({
+        query,
+        mutation,
+        subscription
+    });
+}
+
+export const getGraphQLUnifiedSchemasForModel = (model: GraphQLModel, name: string) => {
     const objectType = generateObjectType(name, model);
     const inputType = generateInputType(name, model);
     const filterType = generateFilterType(name, model);

--- a/src/schema/unified-schema.ts
+++ b/src/schema/unified-schema.ts
@@ -1,5 +1,5 @@
 import { GraphQLObjectType, GraphQLSchema } from 'graphql'
-import { getGraphQLSchemaForModel } from '../generators/get-graphql-schema-for'
+import { getGraphQLUnifiedSchemasForModel } from '../generators/get-graphql-schema-for'
 import { GraphQLModel } from '../types/graphql-model'
 import fs from 'fs'
 import path from 'path'
@@ -21,7 +21,7 @@ export function buildUnifiedGraphQLSchemaFromFolder(modelsDir: string): GraphQLS
         const modelName = path.basename(file, '.ts');
         const { default: model } = require(modelPath) as { default: GraphQLModel };
 
-        const { queryFields: q, mutationFields: m, subscriptionFields: s } = getGraphQLSchemaForModel(model, model.name || modelName);
+        const { queryFields: q, mutationFields: m, subscriptionFields: s } = getGraphQLUnifiedSchemasForModel(model, model.name || modelName);
 
         Object.assign(queryFields, q);
         Object.assign(mutationFields, m);


### PR DESCRIPTION
Refactor the `getGraphQLSchemaForModel` function to return a `GraphQLSchema` and improve logging for query, mutation, and subscription fields. Update references to use the new unified schema generation function.