### PR TITLE
Restructure schema creation logic for clarity and maintainability

### DIFF
--- a/src/schema/unified-schema.ts
+++ b/src/schema/unified-schema.ts
@@ -28,20 +28,32 @@ export function buildUnifiedGraphQLSchemaFromFolder(modelsDir: string): GraphQLS
         Object.assign(subscriptionFields, s);
     }
 
-    const query = new GraphQLObjectType({
-        name: 'Query',
-        fields: queryFields
-    });
+    const schemaConfig: any = {};
 
-    const mutation = new GraphQLObjectType({
-        name: 'Mutation',
-        fields: mutationFields
-    });
+    if (Object.keys(queryFields).length > 0) {
+        schemaConfig.query = new GraphQLObjectType({
+            name: 'Query',
+            fields: queryFields
+        });
+    }
 
-    const subscription = new GraphQLObjectType({
-        name: 'Subscription',
-        fields: subscriptionFields
-    });
+    if (Object.keys(mutationFields).length > 0) {
+        schemaConfig.mutation = new GraphQLObjectType({
+            name: 'Mutation',
+            fields: mutationFields
+        });
+    }
 
-    return new GraphQLSchema({ query, mutation, subscription });
+    if (Object.keys(subscriptionFields).length > 0) {
+        schemaConfig.subscription = new GraphQLObjectType({
+            name: 'Subscription',
+            fields: subscriptionFields
+        });
+    }
+
+    if (!schemaConfig.query && !schemaConfig.mutation && !schemaConfig.subscription) {
+        throw new Error('No GraphQL fields defined — cannot create schema.');
+    }
+
+    return new GraphQLSchema(schemaConfig);
 }


### PR DESCRIPTION
Refactor the schema creation process to improve clarity and maintainability by using a more structured approach to define query, mutation, and subscription fields. This change also adds error handling for cases where no fields are defined.